### PR TITLE
Allowing DataFile's sum_sizes to return None causes rendering

### DIFF
--- a/tardis/tardis_portal/models/datafile.py
+++ b/tardis/tardis_portal/models/datafile.py
@@ -164,7 +164,7 @@ class DataFile(models.Model):
         """
         Takes a query set of datafiles and returns their total size.
         """
-        return datafiles.aggregate(size=Sum('size'))['size']
+        return datafiles.aggregate(size=Sum('size'))['size'] or 0
 
     def save(self, *args, **kwargs):
         if self.size is not None and not isinstance(self.size, (int, long)):


### PR DESCRIPTION
problems in the Facility Overview, so we'll return zero instead.